### PR TITLE
Turn simple-bench into a proper benchmark

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ before_install:
 
 install:
  - cabal-1.24 update
- - cabal-1.24 install --only-dependencies --enable-tests
+ - cabal-1.24 install --only-dependencies --enable-tests --enable-benchmarks
 
 script:
- - cabal-1.24 configure --enable-tests
+ - cabal-1.24 configure --enable-tests --enable-benchmarks
  - cabal-1.24 build
  - cabal-1.24 test --show-details=streaming
  - cabal-1.24 haddock

--- a/bench/simple/Main.hs
+++ b/bench/simple/Main.hs
@@ -5,8 +5,8 @@ module Main (main) where
 import Prelude hiding (read, length)
 import qualified Prelude as P
 
+import Control.Monad
 import Control.Monad.ST
-import Control.Monad.Error
 
 import Data.Char
 import Data.Ord  (comparing)
@@ -40,7 +40,7 @@ alloc arr | len <= 4  = arr `seq` return ()
 
 displayTime :: String -> Integer -> IO ()
 displayTime s elapsed = putStrLn $
-    s ++ " : " ++ show (fromIntegral elapsed / 1e12) ++ " seconds"
+    s ++ " : " ++ show (fromIntegral elapsed / (1e12 :: Double)) ++ " seconds"
 
 run :: String -> IO Integer -> IO ()
 run s t = t >>= displayTime s
@@ -142,7 +142,6 @@ runTest g n k alg = case alg of
   RadixSort          -> sortSuite        "radix sort"            g n   radixSort
   AmericanFlagSort   -> sortSuite        "flag sort"             g n   flagSort
   TimSort            -> sortSuite        "tim sort"              g n   timSort
-  _                  -> putStrLn $ "Currently unsupported algorithm: " ++ show alg
 
 mergeSort :: MVector RealWorld Int -> IO ()
 mergeSort v = M.sort v

--- a/vector-algorithms.cabal
+++ b/vector-algorithms.cabal
@@ -32,7 +32,7 @@ flag InternalChecks
 flag bench
   description: Build a benchmarking program to test vector-algorithms
                performance
-  default: False
+  default: True
 
 flag properties
   description: Enable the quickcheck tests
@@ -100,8 +100,9 @@ library
   if flag(InternalChecks)
     cpp-options: -DVECTOR_INTERNAL_CHECKS
 
-executable simple-bench
+benchmark simple-bench
   hs-source-dirs: bench/simple
+  type: exitcode-stdio-1.0
 
   if !flag(bench)
     buildable: False
@@ -111,7 +112,7 @@ executable simple-bench
   other-modules:
     Blocks
 
-  build-depends: base, mwc-random, vector, vector-algorithms, mtl
+  build-depends: base, mwc-random, vector, vector-algorithms
   ghc-options: -Wall
 
   -- Cabal/Hackage complains about these


### PR DESCRIPTION
`simple-bench` is essentially a `benchmark`, so why not label it as such? This:

* Turns `simple-bench` from an `executable` to a `benchmark`, making it possible to enable with just `--enable-benchmarks` (I had to turn on the `bench` Cabal flag by default to accomplish this).
* Fixes build warnings in `simple-bench`. While doing this, I discovered that we don't actually need to depend on `mtl` in `simple-bench`, so I removed that dependency.
* Tweaks `.travis.yml` to compile the benchmarks on each run.