### PR TITLE
cabal: Version 0.8.0.0

### DIFF
--- a/vector-algorithms.cabal
+++ b/vector-algorithms.cabal
@@ -1,5 +1,5 @@
 name:              vector-algorithms
-version:           0.7.0.4
+version:           0.8.0.0
 license:           BSD3
 license-file:      LICENSE
 author:            Dan Doel
@@ -139,7 +139,7 @@ test-suite properties
       base,
       bytestring,
       containers,
-      QuickCheck >= 2,
+      QuickCheck > 2.9 && < 2.12,
       vector,
       vector-algorithms
 


### PR DESCRIPTION
Some time between 0.7.0.1 and the 0.7.0.2 release the `Lexicographic`
class changed breaking the PVP. Releasing a new major version and will
blacklist/deprecate the broken versions.

Closes: https://github.com/erikd/vector-algorithms/issues/9