### PR TITLE
Expose terminate function

### DIFF
--- a/src/Data/Vector/Algorithms/AmericanFlag.hs
+++ b/src/Data/Vector/Algorithms/AmericanFlag.hs
@@ -28,6 +28,7 @@
 
 module Data.Vector.Algorithms.AmericanFlag ( sort
                                            , sortBy
+                                           , terminate
                                            , Lexicographic(..)
                                            ) where
 

--- a/vector-algorithms.cabal
+++ b/vector-algorithms.cabal
@@ -1,5 +1,5 @@
 name:              vector-algorithms
-version:           0.8.0.1
+version:           0.8.0.2
 license:           BSD3
 license-file:      LICENSE
 author:            Dan Doel


### PR DESCRIPTION
This exposes the terminate function, so that it may used as a parameter to the sortBy function externally.

This would resolve issue #15 