### PR TITLE
Fix bug in Data.Vector.Algorithms.Heaps.heapInsert

### DIFF
--- a/src/Data/Vector/Algorithms/Heap.hs
+++ b/src/Data/Vector/Algorithms/Heap.hs
@@ -265,8 +265,8 @@ heapInsert cmp v l u e = sift (u - l)
  where
  sift k
    | k <= 0    = unsafeWrite v l e
-   | otherwise = let pi = l + shiftR (k-1) 2
-                  in unsafeRead v pi >>= \p -> case cmp p e of
+   | otherwise = let pi = shiftR (k-1) 2
+                  in unsafeRead v (l + pi) >>= \p -> case cmp p e of
                        LT -> unsafeWrite v (l + k) p >> sift pi
                        _  -> unsafeWrite v (l + k) e
 {-# INLINE heapInsert #-}


### PR DESCRIPTION
The previous code confused the index in the original vector and the index shifted by the offset (the `l` in the code), and it would lead to an infinite loop if the offset is non-zero. In order to fix this issue, this commit makes sure that all the index variable in the loop is shifted.

`cabal build`, `test`, `bench` has been run for the rewritten version of the code with GHC 8.8.1, but it may need a review since this package doesn't contain tests for `heapInsert`.