### PR TITLE
Fix out-of-bounds in Timsort

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 
 install:
  - cabal-1.24 update
- - cabal-1.24 install --only-dependencies --enable-tests --enable-benchmarks
+ - cabal-1.24 install --constraint "vector +unsafechecks" --only-dependencies --enable-tests --enable-benchmarks
 
 script:
  - cabal-1.24 configure --enable-tests --enable-benchmarks


### PR DESCRIPTION
It appears that [Timsort implementation](https://github.com/erikd/vector-algorithms/blob/master/src/Data/Vector/Algorithms/Tim.hs) accesses memory out-of-bounds, as can be witnessed by enabling `vector +unsafechecks` flag: https://travis-ci.org/Bodigrim/vector-algorithms/jobs/618361005#log-container

The tricky part is that while the algorithm reads some memory garbage, the latter never makes way into the final result. That is why the bug remained unspotted for so long. In its essence `mergeLo` and `mergeHi` execute the following recursive function:

```haskell
iter :: MVector s a -> Int -> a -> ST s ()
iter vec i vi
  | i < 0 = return ()
  | otherwise = do
    doSmthWith vi
    vi' <- unsafeRead vec (i - 1)
    iter vec (i - 1) vi'
```

As one can see, `iter` reads `vec ! (-1)`, but never actually uses it, so the output remains correct. However, if you are unlucky, `unsafeRead` will trigger a memory access violation.

----

This PR is just a straightforward fix. I understand that it may lack some elegance, and I believe that in future Timsort implementation may benefit from more love. But at the moment I would appreciate a reasonably quick turnaround, because for certain inputs this bug causes a segfault in `poly` package, which may affect its downstream dependencies (CC @sdiehl @Multramate).