### PR TITLE
Intro.partialSort: Fix out-of-range accesses

### DIFF
--- a/src/Data/Vector/Algorithms/Intro.hs
+++ b/src/Data/Vector/Algorithms/Intro.hs
@@ -190,7 +190,10 @@ partialSortByBounds
   -> m ()
 partialSortByBounds cmp a k l u
   | l >= u    = return ()
-  | otherwise = go (ilg len) l (l + k) u
+  | otherwise = let k' = min (u-l) k
+                      -- N.B. Clamp k to the length of the range
+                      -- being sorted.
+                in go (ilg len) l (l + k') u
  where
  isort = introsort cmp a
  {-# INLINE [1] isort #-}


### PR DESCRIPTION
Previously `Data.Vector.Algorithms.Intro.partialSort k v` would
stumble upon undefined behavior via out-of-range array accesses
if `length v < k`. Avoid this by clamping k to the length of the
region being sorted.

This bug can result in segmentation faults and other terrible things.
Consequently, it would be good to release this fix quickly.