### PR TITLE
Allow building with `vector-0.13.*`

### DIFF
--- a/bench/simple/Main.hs
+++ b/bench/simple/Main.hs
@@ -12,7 +12,8 @@ import Data.Char
 import Data.Ord  (comparing)
 import Data.List (maximumBy)
 
-import Data.Vector.Unboxed.Mutable
+import qualified Data.Vector.Unboxed.Mutable as UVector
+import Data.Vector.Unboxed.Mutable (MVector, Unbox)
 
 import qualified Data.Vector.Algorithms.Insertion    as INS
 import qualified Data.Vector.Algorithms.Intro        as INT
@@ -35,8 +36,8 @@ noalgo _ = return ()
 -- Allocates a temporary buffer, like mergesort for similar purposes as noalgo.
 alloc :: (Unbox e) => MVector RealWorld e -> IO ()
 alloc arr | len <= 4  = arr `seq` return ()
-          | otherwise = (new (len `div` 2) :: IO (MVector RealWorld Int)) >> return ()
- where len = length arr
+          | otherwise = (UVector.new (len `div` 2) :: IO (MVector RealWorld Int)) >> return ()
+ where len = UVector.length arr
 
 displayTime :: String -> Integer -> IO ()
 displayTime s elapsed = putStrLn $
@@ -47,7 +48,7 @@ run s t = t >>= displayTime s
 
 sortSuite :: String -> GenIO -> Int -> (MVector RealWorld Int -> IO ()) -> IO ()
 sortSuite str g n sort = do
-  arr <- new n
+  arr <- UVector.new n
   putStrLn $ "Testing: " ++ str
   run "Random            " $ speedTest arr n (rand g >=> modulo n) sort
   run "Sorted            " $ speedTest arr n ascend sort

--- a/src/Data/Vector/Algorithms/Common.hs
+++ b/src/Data/Vector/Algorithms/Common.hs
@@ -121,7 +121,7 @@ resizeVector !src !sz = do
 copyToSmaller
   :: (MVector v a, PrimMonad m)
   => v (PrimState m) a -> v (PrimState m) a -> m ()
-copyToSmaller !dst !src = do_copy 0
+copyToSmaller !dst !src = stToPrim $ do_copy 0
     where
       !n = basicLength dst
 

--- a/src/Data/Vector/Algorithms/Optimal.hs
+++ b/src/Data/Vector/Algorithms/Optimal.hs
@@ -40,6 +40,13 @@ import Data.Vector.Generic.Mutable
 
 import Data.Vector.Algorithms.Common (Comparison)
 
+#if MIN_VERSION_vector(0,13,0)
+import qualified Data.Vector.Internal.Check as Ck
+# define CHECK_INDEX(name, i, n) Ck.checkIndex Ck.Unsafe (i) (n)
+#else
+# define CHECK_INDEX(name, i, n) UNSAFE_CHECK(checkIndex) name (i) (n)
+#endif
+
 #include "vector.h"
 
 -- | Sorts the elements at the positions 'off' and 'off + 1' in the given
@@ -54,8 +61,8 @@ sort2ByOffset cmp a off = sort2ByIndex cmp a off (off + 1)
 -- be the 'lower' of the two.
 sort2ByIndex :: (PrimMonad m, MVector v e)
              => Comparison e -> v (PrimState m) e -> Int -> Int -> m ()
-sort2ByIndex cmp a i j = UNSAFE_CHECK(checkIndex) "sort2ByIndex" i (length a)
-                       $ UNSAFE_CHECK(checkIndex) "sort2ByIndex" j (length a) $  do
+sort2ByIndex cmp a i j = CHECK_INDEX("sort2ByIndex", i, length a)
+                       $ CHECK_INDEX("sort2ByIndex", j, length a) $  do
   a0 <- unsafeRead a i
   a1 <- unsafeRead a j
   case cmp a0 a1 of
@@ -75,9 +82,9 @@ sort3ByOffset cmp a off = sort3ByIndex cmp a off (off + 1) (off + 2)
 -- lowest position in the array.
 sort3ByIndex :: (PrimMonad m, MVector v e)
              => Comparison e -> v (PrimState m) e -> Int -> Int -> Int -> m ()
-sort3ByIndex cmp a i j k = UNSAFE_CHECK(checkIndex) "sort3ByIndex" i (length a)
-                         $ UNSAFE_CHECK(checkIndex) "sort3ByIndex" j (length a)
-                         $ UNSAFE_CHECK(checkIndex) "sort3ByIndex" k (length a) $ do
+sort3ByIndex cmp a i j k = CHECK_INDEX("sort3ByIndex", i, length a)
+                         $ CHECK_INDEX("sort3ByIndex", j, length a)
+                         $ CHECK_INDEX("sort3ByIndex", k, length a) $ do
   a0 <- unsafeRead a i
   a1 <- unsafeRead a j
   a2 <- unsafeRead a k
@@ -114,10 +121,10 @@ sort4ByOffset cmp a off = sort4ByIndex cmp a off (off + 1) (off + 2) (off + 3)
 -- it can be used to sort medians into particular positions and so on.
 sort4ByIndex :: (PrimMonad m, MVector v e)
              => Comparison e -> v (PrimState m) e -> Int -> Int -> Int -> Int -> m ()
-sort4ByIndex cmp a i j k l = UNSAFE_CHECK(checkIndex) "sort4ByIndex" i (length a)
-                           $ UNSAFE_CHECK(checkIndex) "sort4ByIndex" j (length a)
-                           $ UNSAFE_CHECK(checkIndex) "sort4ByIndex" k (length a)
-                           $ UNSAFE_CHECK(checkIndex) "sort4ByIndex" l (length a) $ do
+sort4ByIndex cmp a i j k l = CHECK_INDEX("sort4ByIndex", i, length a)
+                           $ CHECK_INDEX("sort4ByIndex", j, length a)
+                           $ CHECK_INDEX("sort4ByIndex", k, length a)
+                           $ CHECK_INDEX("sort4ByIndex", l, length a) $ do
   a0 <- unsafeRead a i
   a1 <- unsafeRead a j
   a2 <- unsafeRead a k

--- a/tests/properties/Optimal.hs
+++ b/tests/properties/Optimal.hs
@@ -8,7 +8,7 @@ module Optimal where
 import Control.Arrow
 import Control.Monad
 
-import Data.List
+import qualified Data.List as List
 import Data.Function
 
 import Data.Vector.Generic hiding (map, zip, concatMap, (++), replicate, foldM)
@@ -32,18 +32,18 @@ monotones k = atLeastOne 0
 stability :: (Vector v (Int,Int)) => Int -> [v (Int, Int)]
 stability n = concatMap ( map fromList
                         . foldM interleavings []
-                        . groupBy ((==) `on` fst)
+                        . List.groupBy ((==) `on` fst)
                         . flip zip [0..])
               $ monotones (n-2) n
 
 sort2 :: (Vector v Int) => [v Int]
-sort2 = map fromList $ permutations [0,1]
+sort2 = map fromList $ List.permutations [0,1]
 
 stability2 :: (Vector v (Int,Int)) => [v (Int, Int)]
 stability2 = [fromList [(0, 0), (0, 1)]]
 
 sort3 :: (Vector v Int) => [v Int]
-sort3 = map fromList $ permutations [0..2]
+sort3 = map fromList $ List.permutations [0..2]
 
 {-
 stability3 :: [UArr (Int :*: Int)]
@@ -58,5 +58,5 @@ stability3 = map toU [ [0:*:0, 0:*:1, 0:*:2]
 -}
 
 sort4 :: (Vector v Int) => [v Int]
-sort4 = map fromList $ permutations [0..3]
+sort4 = map fromList $ List.permutations [0..3]
 


### PR DESCRIPTION
Adapted from the patch in erikd/vector-algorithms#39, with some minor tweaks:

* Since the `HasCallStack` constraint isn't available on all versions of GHC that `vector-algorithms` supports, I decided to omit the additional `HasCallStack` constraints that erikd/vector-algorithms#39 adds.
* I used `stToPrim` to accommodate the generic `Vector` classes specializing all of the monads to `ST` instead of being polymorphic over `MonadPrim m`.
* I also fixed the benchmark suite.