### PR TITLE
Mark `nub` and `sort` functions as `INLINE`

### DIFF
--- a/src/Data/Vector/Algorithms.hs
+++ b/src/Data/Vector/Algorithms.hs
@@ -18,6 +18,7 @@ import qualified Data.Vector.Algorithms.Search  as S
 -- | The `nub` function which removes duplicate elements from a vector.
 nub :: forall v e . (V.Vector v e, Ord e) => v e -> v e
 nub = nubBy compare
+{-# INLINE nub #-}
 
 -- | A version of `nub` with a custom comparison predicate.
 --
@@ -31,6 +32,7 @@ nubBy cmp vec = runST $ do
   destMV <- nubByMut sortUniqBy cmp mv
   v <- V.unsafeFreeze destMV
   pure (V.force v)
+{-# INLINE nubBy #-}
 
 -- | The `nubByMut` function takes in an in-place sort algorithm
 -- and uses it to do a de-deduplicated sort. It then uses this to
@@ -72,3 +74,4 @@ nubByMut alg cmp inp = do
               go (srcInd + 1) (destInd + 1)
   go 0 0
   pure dest
+{-# INLINABLE nubByMut #-}

--- a/src/Data/Vector/Algorithms/AmericanFlag.hs
+++ b/src/Data/Vector/Algorithms/AmericanFlag.hs
@@ -244,7 +244,7 @@ sort :: forall e m v. (PrimMonad m, MVector v e, Lexicographic e, Ord e)
 sort v = sortBy compare terminate (size p) index v
  where p :: Proxy e
        p = Proxy
-{-# INLINABLE sort #-}
+{-# INLINE sort #-}
 
 -- | A variant on `sort` that returns a vector of unique elements.
 sortUniq :: forall e m v. (PrimMonad m, MVector v e, Lexicographic e, Ord e)
@@ -252,7 +252,7 @@ sortUniq :: forall e m v. (PrimMonad m, MVector v e, Lexicographic e, Ord e)
 sortUniq v = sortUniqBy compare terminate (size p) index v
  where p :: Proxy e
        p = Proxy
-{-# INLINABLE sortUniq #-}
+{-# INLINE sortUniq #-}
 
 -- | A fully parameterized version of the sorting algorithm. Again, this
 -- function takes both radix information and a comparison, because the

--- a/src/Data/Vector/Algorithms/Heap.hs
+++ b/src/Data/Vector/Algorithms/Heap.hs
@@ -56,12 +56,12 @@ import qualified Data.Vector.Algorithms.Optimal as O
 -- | Sorts an entire array using the default ordering.
 sort :: (PrimMonad m, MVector v e, Ord e) => v (PrimState m) e -> m ()
 sort = sortBy compare
-{-# INLINABLE sort #-}
+{-# INLINE sort #-}
 
 -- | A variant on `sort` that returns a vector of unique elements.
 sortUniq :: (PrimMonad m, MVector v e, Ord e) => v (PrimState m) e -> m (v (PrimState m) e)
 sortUniq = sortUniqBy compare
-{-# INLINABLE sortUniq #-}
+{-# INLINE sortUniq #-}
 
 -- | Sorts an entire array using a custom ordering.
 sortBy :: (PrimMonad m, MVector v e) => Comparison e -> v (PrimState m) e -> m ()

--- a/src/Data/Vector/Algorithms/Insertion.hs
+++ b/src/Data/Vector/Algorithms/Insertion.hs
@@ -36,12 +36,12 @@ import qualified Data.Vector.Algorithms.Optimal as O
 -- | Sorts an entire array using the default comparison for the type
 sort :: (PrimMonad m, MVector v e, Ord e) => v (PrimState m) e -> m ()
 sort = sortBy compare
-{-# INLINABLE sort #-}
+{-# INLINE sort #-}
 
 -- | A variant on `sort` that returns a vector of unique elements.
 sortUniq :: (PrimMonad m, MVector v e, Ord e) => v (PrimState m) e -> m (v (PrimState m) e)
 sortUniq = sortUniqBy compare
-{-# INLINABLE sortUniq #-}
+{-# INLINE sortUniq #-}
 
 -- | Sorts an entire array using a given comparison
 sortBy :: (PrimMonad m, MVector v e) => Comparison e -> v (PrimState m) e -> m ()

--- a/src/Data/Vector/Algorithms/Intro.hs
+++ b/src/Data/Vector/Algorithms/Intro.hs
@@ -67,12 +67,12 @@ import qualified Data.Vector.Algorithms.Heap      as H
 -- | Sorts an entire array using the default ordering.
 sort :: (PrimMonad m, MVector v e, Ord e) => v (PrimState m) e -> m ()
 sort = sortBy compare
-{-# INLINABLE sort #-}
+{-# INLINE sort #-}
 
 -- | A variant on `sort` that returns a vector of unique elements.
 sortUniq :: (PrimMonad m, MVector v e, Ord e) => v (PrimState m) e -> m (v (PrimState m) e)
 sortUniq = sortUniqBy compare
-{-# INLINABLE sortUniq #-}
+{-# INLINE sortUniq #-}
 
 -- | A variant on `sortBy` which returns a vector of unique elements.
 sortBy :: (PrimMonad m, MVector v e) => Comparison e -> v (PrimState m) e -> m ()

--- a/src/Data/Vector/Algorithms/Merge.hs
+++ b/src/Data/Vector/Algorithms/Merge.hs
@@ -37,12 +37,12 @@ import qualified Data.Vector.Algorithms.Insertion as I
 -- | Sorts an array using the default comparison.
 sort :: (PrimMonad m, MVector v e, Ord e) => v (PrimState m) e -> m ()
 sort = sortBy compare
-{-# INLINABLE sort #-}
+{-# INLINE sort #-}
 
 -- | A variant on `sort` that returns a vector of unique elements.
 sortUniq :: (PrimMonad m, MVector v e, Ord e) => v (PrimState m) e -> m (v (PrimState m) e)
 sortUniq = sortUniqBy compare
-{-# INLINABLE sortUniq #-}
+{-# INLINE sortUniq #-}
 
 -- | Sorts an array using a custom comparison.
 sortBy :: (PrimMonad m, MVector v e) => Comparison e -> v (PrimState m) e -> m ()

--- a/src/Data/Vector/Algorithms/Radix.hs
+++ b/src/Data/Vector/Algorithms/Radix.hs
@@ -186,7 +186,7 @@ sort arr = sortBy (passes e) (size e) radix arr
  where
  e :: e
  e = undefined
-{-# INLINABLE sort #-}
+{-# INLINE sort #-}
 
 -- | Radix sorts an array using custom radix information
 -- requires the number of passes to fully sort the array,

--- a/src/Data/Vector/Algorithms/Tim.hs
+++ b/src/Data/Vector/Algorithms/Tim.hs
@@ -113,12 +113,12 @@ import Data.Vector.Algorithms.Common (uniqueMutableBy)
 -- | Sorts an array using the default comparison.
 sort :: (PrimMonad m, MVector v e, Ord e) => v (PrimState m) e -> m ()
 sort = sortBy compare
-{-# INLINABLE sort #-}
+{-# INLINE sort #-}
 
 -- | A variant on `sort` that returns a vector of unique elements.
 sortUniq :: (PrimMonad m, MVector v e, Ord e) => v (PrimState m) e -> m (v (PrimState m) e)
 sortUniq = sortUniqBy compare
-{-# INLINABLE sortUniq #-}
+{-# INLINE sortUniq #-}
 
 -- | Sorts an array using a custom comparison.
 sortBy :: (PrimMonad m, MVector v e)


### PR DESCRIPTION
Fixes #50. Notes:

- `nubByMut` is marked as `INLINABLE`. Change it to `INLINE` if it's faster in some case.
- `sortUniq` is marked as `INLINE`, but without any benchmark. I guess it's ok as it's very small.
